### PR TITLE
Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ outputs:
     description: "Digital outputs, just as names"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Following the recent blog post ["GitHub Actions: Transitioning from Node 16 to Node 20"](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20//) by GitHub, I noticed this action is still running on node16:

action.yml

runs:
  using: 'node16'
  main: 'dist/index.js'
This is the warning I see every time I my workflow:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: josStorer/get-current-time@master. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```